### PR TITLE
Testnet update: Use data-avail

### DIFF
--- a/docker-compose.da-val-1.yml
+++ b/docker-compose.da-val-1.yml
@@ -2,11 +2,10 @@ version: "3.3"
 services:
   validator1:
     container_name: validator1 
-    image: da:poc3 
+    image: da:mat-3347
     tmpfs: /tmp
     volumes:
       - validator1-state:/da/state
-      - ./volume/stage/customSpec.json:/da/chain_spec.json:ro
       - ./volume/stage/validator1/node.private.key:/da/node.key:ro
       - ./volume/stage/validator1/keystore:/da/keystore
     ports:
@@ -20,7 +19,7 @@ services:
         max_attempts: 3
     command: 
       --validator
-      --chain /da/chain_spec.json
+      --chain /da/genesis/testnet.chain.spec.raw.json
       --base-path /da/state
       --name MATIC_VALIDATOR_1
       --node-key-file /da/node.key

--- a/docker-compose.da-val-2.yml
+++ b/docker-compose.da-val-2.yml
@@ -2,11 +2,10 @@ version: "3.3"
 services:
   validator2:
     container_name: validator2
-    image: da:poc3 
+    image: da:mat-3347
     tmpfs: /tmp
     volumes:
       - validator2-state:/da/state
-      - ./volume/stage/customSpec.json:/da/chain_spec.json:ro
       - ./volume/stage/validator2/node.private.key:/da/node.key:ro
       - ./volume/stage/validator2/keystore:/da/keystore
     ports:
@@ -20,7 +19,7 @@ services:
         max_attempts: 3
     command: 
       --validator
-      --chain /da/chain_spec.json
+      --chain /da/genesis/testnet.chain.spec.raw.json
       --base-path /da/state
       --name MATIC_VALIDATOR_2
       --node-key-file /da/node.key

--- a/docker-compose.da-val-3.yml
+++ b/docker-compose.da-val-3.yml
@@ -2,11 +2,10 @@ version: "3.3"
 services:
   validator3:
     container_name: validator3
-    image: da:poc3 
+    image: da:mat-3347
     tmpfs: /tmp
     volumes:
       - validator3-state:/da/state
-      - ./volume/stage/customSpec.json:/da/chain_spec.json:ro
       - ./volume/stage/validator3/node.private.key:/da/node.key:ro
       - ./volume/stage/validator3/keystore:/da/keystore
     ports:
@@ -20,7 +19,7 @@ services:
         max_attempts: 3
     command: 
       --validator
-      --chain /da/chain_spec.json
+      --chain /da/genesis/testnet.chain.spec.raw.json
       --base-path /da/state
       --name MATIC_VALIDATOR_3
       --node-key-file /da/node.key

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,10 +3,10 @@ services:
   alice:
     container_name: alice 
     build:
-      context: ./images/node
+      context: ./images/da
       args:
-        - BRANCH=da-poc
-    image: da:poc 
+        - BRANCH=miguel/mat-3347-new-chain-spec-for-dev-testnet
+    image: da:latest
     tmpfs: /tmp
     volumes:
       - alice-state:/da/state

--- a/docker-compose.full-node.yml
+++ b/docker-compose.full-node.yml
@@ -2,11 +2,10 @@ version: "3.3"
 services:
   full_node:
     container_name: full_node
-    image: da:poc3 
+    image: da:mat-3347
     tmpfs: /tmp
     volumes:
       - full_node-state:/da/state
-      - ./volume/stage/customSpec.json:/da/chain_spec.json:ro
     ports:
       - 9933:9933
       - 9944:9944
@@ -17,7 +16,7 @@ services:
         delay: 5s
         max_attempts: 3
     command: 
-      --chain /da/chain_spec.json
+      --chain /da/genesis/testnet.chain.spec.raw.json
       --base-path /da/state
       --name MATIC_FULLNODE
       --keystore-path /da/keystore
@@ -34,9 +33,7 @@ services:
 
   dapp:
     container_name: dapp 
-    build:
-      context: ./images/dapp
-    image: da-app:master
+    image: dapp:asdr
     environment:
       - WS_URL=wss://polygon-da-explorer.matic.today/ws
 

--- a/images/da/Dockerfile
+++ b/images/da/Dockerfile
@@ -12,12 +12,14 @@ ARG BRANCH=master
 RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 RUN --mount=type=ssh \
+	mkdir -p /da/bin && \
+	mkdir -p /da/genesis && \
 	# Build DA \
 	git clone --branch ${BRANCH} git@github.com:maticnetwork/avail.git && \
+	cp -r avail/misc/genesis /da && \
 	cd avail && \
 	cargo build --release && \
 	# Install binaries \ 
-	mkdir -p /da/bin && \
 	mv target/release/data-avail /da/bin && \
 	# and clean \
 	cd .. && \

--- a/images/dapp/Dockerfile
+++ b/images/dapp/Dockerfile
@@ -1,26 +1,27 @@
 # Phase 0: Builder
 # ========================= 
-FROM ubuntu:18.04 as builder
+FROM node:14-bullseye as builder
    
 RUN apt-get update && \
 	apt-get install -y curl git gnupg && \
-	curl -sL https://deb.nodesource.com/setup_10.x -o setup_10.x && \
-	bash setup_10.x && \
-	apt-get install -y nodejs && \
 	rm -rf /var/lib/apt/lists 
- 
+
+# Download public key for github.com
+RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+
 ARG BRANCH=master
 ARG NODE_ENV=production
 
-RUN \ 
+RUN --mount=type=ssh \
 	# Build DApp \
-	git clone --branch ${BRANCH} --depth 1 https://github.com/maticnetwork/apps.git && \
-	cd apps && \
-	npm install yarn -g && \
-	yarn && \
-	yarn build:www
+	git clone --branch ${BRANCH} https://github.com/maticnetwork/apps.git
 
-RUN mv apps/packages/apps/build /html && \
+RUN --mount=type=ssh \
+	cd apps && \
+	yarn && \
+	yarn build:www && \
+	mv packages/apps/build /html && \
+	cd .. && \
 	rm -rf apps
 
 # Phase 1: Web Service deployment with static 


### PR DESCRIPTION
- [x] Changes on Testnet deployment: Validators 1,2,3 and explorer
- [x] Data-Avail image includes any genesis from repo.
- [x] DApp (explorer) image supports `ASDR` branch.