### PR TITLE
Add `polygon-da-light.matic.today`

### DIFF
--- a/docker-compose.polygon-da-light.matic.today.yml
+++ b/docker-compose.polygon-da-light.matic.today.yml
@@ -1,0 +1,36 @@
+version: "3.3"
+services: 
+  light_client: 
+    image: client:asdr
+    volumes: 
+      - light_client_state:/avail-light/ipfs_store
+    environment:
+      - HTTP_SERVER_HOST=0.0.0.0
+      - FULL_NODE_RPC="http://polygon-da-explorer.matic.today:9933"
+      - FULL_NODE_WS="wss://polygon-da-explorer.matic.today/ws"
+      - IPFS_PATH=/avail-light/ipfs_store
+
+  # Redis is used to store certificates
+  redis:
+    image:  redis:6-alpine
+    command: "redis-server --save 60 1"
+    volumes:
+      - ./volume/redis/data:/data
+
+  # HTTPS proxy
+  proxy:
+    image: kong:2.6.0-alpine
+    env_file: env/proxy.env
+    depends_on:
+      - light_client
+      - redis
+    volumes:
+      - ./volume/proxy/kong.polygon-da-light.yml:/proxy/kong.yml:ro
+    ports:
+      - 443:8443
+      - 80:8000
+
+volumes:
+  light_client_state:
+
+# vim: ts=2:et

--- a/images/client/Dockerfile
+++ b/images/client/Dockerfile
@@ -30,7 +30,7 @@ FROM debian:buster-slim
 
 # Install ssh client and git
 RUN apt-get update && \
-	apt-get install -y libssl1.1 gettext-base wait-for-it && \
+	apt-get install -y libssl1.1 gettext-base wait-for-it ca-certificates && \
 	rm -rf /var/lib/apt/lists 
 
 COPY --from=builder /avail-light /avail-light

--- a/volume/proxy/kong.polygon-da-light.yml
+++ b/volume/proxy/kong.polygon-da-light.yml
@@ -1,0 +1,34 @@
+_format_version: "2.1"
+
+services:
+ - name: light_client 
+   url: http://light_client:7000
+   tags: ["lc"]
+   routes:
+   - name: lc_route
+     protocols: ["https", "http"]
+     paths: ["/"]
+     request_buffering: false
+     response_buffering: false
+     strip_path: true
+     # preserve_host: true
+
+ - name: acme-dummy
+   url: http://127.0.0.1:65535
+   routes:
+   - name: acme-dummy
+     protocols: ["http"]
+     paths: ["/.well-known/acme-challenge"]
+
+
+plugins:
+  - name: acme
+    config:
+      account_email: miguel@polygon.technology
+      domains: ["polygon-da-light.matic.today"]
+      tos_accepted: true
+      # api_uri: https://acme-staging-v02.api.letsencrypt.org/directory
+      storage: "redis"
+      storage_config:
+        redis:
+          host: redis


### PR DESCRIPTION
- Add simple orchestration for  `polygon-da-light.matic.today`
- LC images support TLS connections (like `wss://`)